### PR TITLE
Add interface check for docsim 0.1.3

### DIFF
--- a/docsim.el
+++ b/docsim.el
@@ -280,6 +280,10 @@ backed by a file and (2) `docsim-denote-omit-links' is t."
          (path (substring line (1+ (length score)))))
     (cons path score)))
 
+(defun docsim--version ()
+  "Get current version of the `docsim-executable'."
+  (string-trim (shell-command-to-string (format "%s --version" docsim-executable))))
+
 (defun docsim--quote-path (path)
   "Wrap PATH in quotes for interpolation into a shell command."
   (cl-check-type path string)
@@ -302,6 +306,7 @@ backed by a file and (2) `docsim-denote-omit-links' is t."
                     `(,docsim-executable
                       "--best-first"
                       "--show-scores"
+                      ,@(when (not (string= (docsim--version) "0.1.3")) '("--stdin"))
                       ,@(docsim--stemming-stoplist-flags)
                       ,@(mapcar #'docsim--quote-path docsim-search-paths))
                     " ")))
@@ -336,7 +341,8 @@ backed by a file, pass that file as an argument to `docsim')."
                   "--omit-query"
                   "--show-scores"
                   ,@(docsim--stemming-stoplist-flags)
-                  "--query" ,(docsim--quote-path (buffer-file-name query))
+                  ,(if (string= (docsim--version) "0.1.3") "--query" "--file")
+                  ,(docsim--quote-path (buffer-file-name query))
                   ,@(mapcar #'docsim--quote-path docsim-search-paths))
                 " ")))
 


### PR DESCRIPTION
`docsim` 0.1.4 will be [updating the command-line interface in breaking ways](https://github.com/hrs/docsim/pull/5), and a few people might still have 0.1.3 installed, so it'd be nice to handle that transition smoothly.

Realistically we ought to be able to remove this check in a week or two; I just don't want to scare people off while the project's brand new. :-)