### PR TITLE
Convert unit tests to buttercup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
 
     - name: Run tests
       if: matrix.allow_failure != true
-      run: 'make && make test'
+      run: 'make test'
 
     - name: Run tests (allow failure)
       if: matrix.allow_failure == true
-      run: 'make && make test || true'
+      run: 'make test || true'

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 .PHONY: test
 test: docsim.el docsim-test.el
 	emacs --quick --batch \
-	-l ert \
+	-f package-initialize \
+  --eval "(add-to-list 'package-archives '(\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") t)" \
+  --eval "(when (not (package-installed-p 'buttercup)) (package-refresh-contents) (package-install 'buttercup))" \
+	-l buttercup \
 	-l org \
 	-l org-element \
-	-l docsim-test.el \
-	--eval "(setq ert-batch-backtrace-right-margin 10000)" \
-	-f ert-run-tests-batch-and-exit
+	-L . \
+	-f buttercup-run-discover
 
 .PHONY: lint
 lint: byte_compile package_lint

--- a/docsim.el
+++ b/docsim.el
@@ -153,13 +153,13 @@ results buffer will show the file's relative path.")
                                  (cl-typep score 'docsim-score))
                                scores)))))
 
-(defun docsim--get-title-markdown-yaml ()
+(defun docsim--get-title-yaml ()
   "Attempt to parse `title' from YAML front matter in the current buffer.
 
-This treats the current buffer as if it contains Markdown with
-YAML front matter, as used, for example, in Jekyll blog posts. It
-attempts to parse out and return the value associated with the
-`title' key. If that's not found, return nil."
+This treats the current buffer as if it contains YAML front
+matter, as used, for example, in Jekyll blog posts. It attempts
+to parse out and return the value associated with the `title'
+key. If that's not found, return nil."
   (save-excursion
     (goto-char (point-min))
     (when (looking-at "^---$")
@@ -190,7 +190,7 @@ attempts to parse out and return value associated with the
     (insert-file-contents path)
   (if (string= "org" (file-name-extension path))
       (docsim--get-title-org)
-    (docsim--get-title-markdown-yaml))))
+    (docsim--get-title-yaml))))
 
 (defun docsim--relative-path (path)
   "Return the relative path of PATH in one of `docsim-search-paths'.


### PR DESCRIPTION
Buttercup provides spies and other functions that are handy when testing UI elements. Our UI tests don't really exist, and we'll want those when we backfill them.

The errors and diffs that buttercup provides are also a bit more readable than ert's, IMHO.